### PR TITLE
Add registry-based pdf_id filtering

### DIFF
--- a/tests/test_registry_filter.py
+++ b/tests/test_registry_filter.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from filter_utils import registry_pdf_id_filter
+
+
+def test_registry_pdf_id_filter_excludes_expired():
+    df = pd.read_excel('tests/LIBRARY_UNIFIED_sample.xlsx')
+    all_ids = registry_pdf_id_filter(df, {'scope': 'national'})
+    filtered_ids = registry_pdf_id_filter(df, {'scope': 'national', 'exclude_expired': True})
+    assert len(filtered_ids) < len(all_ids)
+    assert set(filtered_ids).issubset(set(all_ids))
+    assert all(isinstance(x, str) for x in filtered_ids)


### PR DESCRIPTION
## Summary
- update retrieval filter builder to restrict by pdf_id list
- add helper to obtain pdf_ids from registry data
- integrate registry filtering in RAG pipeline
- test registry-based pdf_id filtering

## Testing
- `pyright filter_utils.py rag.py tests/test_registry_filter.py`
- `pytest tests/test_registry_filter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685058756204832fabfc7dfa7879021f