### PR TITLE
Remove obsolete qdrant metadata usage

### DIFF
--- a/filter_utils.py
+++ b/filter_utils.py
@@ -4,116 +4,17 @@ import pandas as pd
 from qdrant_client.http import models
 
 
+
 def build_retrieval_filter(
     filter_conditions: Optional[dict[str, str | bool | None]] = None,
     allowed_pdf_ids: Optional[List[str]] = None,
 ) -> Optional[models.Filter]:
-    """
-    Build a Qdrant Filter from the user's `filter_conditions`.
+    """Return a Qdrant filter limited to ``pdf_id`` values.
 
-    ── Logic ──────────────────────────────────────────────────────────────
-    • Everything in `must` is an AND that applies to *all* documents
-      (public_release, exclude_expired, other boolean flags, …).
-
-    • `scope` and `unit` live in `should` so we can say
-        (scope = user's scope  [AND unit = user's unit, if any])
-        OR
-        (scope = "national")
-
-      This returns national documents **plus** the user‑requested district/local
-      docs, but still respects the other global requirements in `must`.
-      
-      EXAMPLE OUTPUT:
-      should=[                ← This is doing the OR of `scope` national or district
-        Filter(               ← top‑level “should” list
-            should=None,        ← this is the **nested** Filter’s own should (it’s doing an AND of scope+unit)
-            must=[
-                FieldCondition(scope="District"),
-                FieldCondition(unit="7")
-            ]
-        ),
-            FieldCondition(scope="national")  ← second branch of the top‑level should
-        ]
-        must=[
-            FieldCondition(public_release=True)
-        ]
+    All other filtering is handled using the registry.
     """
 
-    fc = (filter_conditions or {}).copy()      # defensive copy
-    must: list[models.Filter | models.FieldCondition] = []
-    should: list[models.Filter | models.FieldCondition] = []
-
-    # ── 1.  Global requirements (goes in MUST (AND)───────────────────────────────
-    # Handle Expiration_date
-    if fc.pop("exclude_expired", False):
-        must.append(
-            models.FieldCondition(
-                key="metadata.expiration_date",
-                range=models.DatetimeRange(gt=datetime.now(timezone.utc).isoformat()),
-            )
-        )
-
-    # Handle other boolean flags
-    for key, value in list(fc.items()):
-        if key in {"aux_specific"}:
-            continue
-        if value is True: 
-            must.append(
-                models.FieldCondition(
-                    key=f"metadata.{key}", match=models.MatchValue(value=True)
-                )
-            )
-
-    # ── 2.  Handle scope & unit (goes in SHOULD) ─────────────────────────
-    scope_val: str | None = fc.get("scope")
-    unit_val: str | None = fc.get("unit")
-
-    if scope_val and scope_val.lower() != "national":
-        # (a) District / Local filter  ➜ scope AND (optional) unit
-        scope_unit_must: list[models.FieldCondition] = [
-            models.FieldCondition(
-                key="metadata.scope", match=models.MatchValue(value=scope_val)
-            )
-        ]
-        if unit_val:
-            scope_unit_must.append(
-                models.FieldCondition(
-                    key="metadata.unit", match=models.MatchValue(value=unit_val)
-                )
-            )
-        should.append(models.Filter(must=scope_unit_must))
-
-        # (b) National fallback
-        should.append(
-            models.FieldCondition(
-                key="metadata.scope", match=models.MatchValue(value="national")
-            )
-        )
-
-    elif scope_val and scope_val.lower() == "national":
-        # User explicitly asked for national only
-        must.append(
-            models.FieldCondition(
-                key="metadata.scope", match=models.MatchValue(value="national")
-            )
-        )
-        if unit_val:                     # unlikely, but honour it if supplied
-            must.append(
-                models.FieldCondition(
-                    key="metadata.unit", match=models.MatchValue(value=unit_val)
-                )
-            )
-
-    else:
-        # No scope given ⇒ leave scope open; but still pin unit if supplied
-        if unit_val:
-            must.append(
-                models.FieldCondition(
-                    key="metadata.unit", match=models.MatchValue(value=unit_val)
-                )
-            )
-
-    # Apply pdf_id allow list if provided
+    must: list[models.FieldCondition] = []
     if allowed_pdf_ids is not None:
         must.append(
             models.FieldCondition(
@@ -122,11 +23,7 @@ def build_retrieval_filter(
             )
         )
 
-    # ── 3.  Return assembled filter ─────────────────────────────────────
-    if not must and not should:
-        return None                      # no filters at all
-
-    return models.Filter(must=must, should=should)
+    return models.Filter(must=must) if must else None
 
 
 def registry_pdf_id_filter(
@@ -151,6 +48,12 @@ def registry_pdf_id_filter(
     """
     fc = (filter_conditions or {}).copy()
     df = registry_df.copy()
+
+    # Apply boolean flag filters
+    for flag in ("public_release", "aux_specific"):
+        if flag in df.columns and flag in fc:
+            val = fc.pop(flag)
+            df = df[df[flag].astype(str).str.lower() == str(val).lower()]
 
     if fc.pop("exclude_expired", False) and "expiration_date" in df.columns:
         now = datetime.now(timezone.utc)

--- a/rag.py
+++ b/rag.py
@@ -303,18 +303,17 @@ def create_source_lists(response, registry_df: pd.DataFrame | None = None):
 
         title = row.get('title', '')
         date = row.get('issue_date', '')[:4]
-        page = str(int(doc.metadata.get('page', 0)) + 1)
         publication_number = (lambda x: (s := str(x).strip()) and s or " ")(row.get('publication_number'))
         scope = (lambda x: " " if not x or str(x).strip().lower() == "national" else str(x).strip())(row.get('scope'))
         unit = (lambda x: (s := str(x).strip()) and s or " ")(row.get('unit'))
         organization = (lambda x: f"Issuer: {x.strip()}" if x and x.strip() else None)(row.get('organization'))
 
 
-        short_source_markdown_list.append(f"  *{scope} {unit} {title} [{date}], page {page}\n  ")
+        short_source_markdown_list.append(f"  *{scope} {unit} {title} [{date}]\n  ")
         
         page_content = doc.page_content  
         long_source_markdown_list.append(
-            f"**Reference {i}:**  \n    {scope} {unit} {title} [{date}], page {page}  \n  {publication_number}  \n  {organization}\n   {scope} {unit}\n\n  "
+            f"**Reference {i}:**  \n    {scope} {unit} {title} [{date}]  \n  {publication_number}  \n  {organization}\n   {scope} {unit}\n\n  "
             f"{page_content}\n\n  "
             f"***  "
         )


### PR DESCRIPTION
## Summary
- drop qdrant metadata fields from `build_retrieval_filter`
- filter boolean flags in registry helper instead of qdrant
- stop referencing `page` metadata from qdrant results

## Testing
- `pyright`
- `pytest -q` *(fails: StreamlitSecretNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685061c084f8832f9f34fd55e33e6407